### PR TITLE
Add recent songs endpoint per user

### DIFF
--- a/src/Functions/Common/FunctionNames.cs
+++ b/src/Functions/Common/FunctionNames.cs
@@ -6,6 +6,7 @@ namespace Functions.Common
         public const string HttpCallback = "Http_AuthorizeCallback";
         public const string HttpUsers = "Http_Users";
         public const string HttpListenerTracks = "Http_ListenerTracks";
+        public const string HttpRecentlyPlayed = "Http_RecentlyPlayed";
         public const string HttpSignalRNegotiate = "Http_SignalRNegotiate";
         public const string NowPlayingOrchestrator = "O_NowPlaying";
         public const string GetCurrentTracksActivity = "A_GetCurrentTracks";

--- a/src/Functions/Common/SpotifyHelper.cs
+++ b/src/Functions/Common/SpotifyHelper.cs
@@ -13,7 +13,7 @@ namespace Functions.Common
 {
     public class SpotifyHelper
     {
-        public static async Task<CurrentTrack> GetCurrentTrackAsync(string userId)
+        private static async Task<string> GetAccessToken(string userId)
         {
             TokenSecrets tokens = null;
             try
@@ -34,7 +34,21 @@ namespace Functions.Common
                 await SecretRepository.SaveToken(userId, tokens);
             }
 
-            return await SpotifyApi.GetCurrentTrackAsync(tokens.AccessToken);
+            return tokens.AccessToken;
+        }
+
+        public static async Task<CurrentTrack> GetCurrentTrackAsync(string userId)
+        {
+            var accessToken = await GetAccessToken(userId);
+
+            return await SpotifyApi.GetCurrentTrackAsync(accessToken);
+        }
+
+        public static async Task<PlayHistory> GetRecentlyPlayedTracksAsync(string userId)
+        {
+            var accessToken = await GetAccessToken(userId);
+
+            return await SpotifyApi.GetRecentlyPlayedTracksAsync(accessToken);
         }
 
         public static async Task<List<ListenerTrack>> GetListenerTracks(List<string> userIds, ILogger log)
@@ -50,7 +64,7 @@ namespace Functions.Common
         {
             try
             {
-                var currentTrack = await SpotifyHelper.GetCurrentTrackAsync(userId);
+                var currentTrack = await GetCurrentTrackAsync(userId);
                 return new ListenerTrack
                 {
                     userId = userId,

--- a/src/Functions/HttpRecentlyPlayed.cs
+++ b/src/Functions/HttpRecentlyPlayed.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage.Table;
+using Functions.Common;
+using Functions.Repositories;
+using Functions.Models.Orchestrator;
+using Spotify.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Functions
+{
+    public static class HttpRecentlyPlayed
+    {
+        [FunctionName(FunctionNames.HttpRecentlyPlayed)]
+        public static async Task<IActionResult> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "recent/{userId}")] HttpRequest req,
+            [Table(
+                TableConstants.UserTable,
+                Connection = Constants.StorageConnection
+            )] CloudTable userTable,
+            string userId,
+            ILogger log)
+        {
+            await userTable.CreateIfNotExistsAsync();
+
+            var repo = new UserRepository(userTable);
+            var entity = await repo.GetUserAsync(userId);
+
+            if (entity != null && entity.Active)
+            {
+                var playHistory = await SpotifyHelper.GetRecentlyPlayedTracksAsync(userId);
+
+                return new JsonResult(playHistory);
+            }
+
+            return new NotFoundResult();
+        }
+    }
+}

--- a/src/Functions/Repositories/UserRepository.cs
+++ b/src/Functions/Repositories/UserRepository.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Functions.Common;
 using Functions.Extensions;
 using Functions.Models.Table;
 using Microsoft.WindowsAzure.Storage.Table;
@@ -17,6 +18,20 @@ namespace Functions.Repositories
         public async Task<IList<UserEntity>> GetUsersAsync()
         {
             return await _table.ExecuteQueryAsync(new TableQuery<UserEntity>());
+        }
+
+        public async Task<UserEntity> GetUserAsync(string userId)
+        {
+            try
+            {
+                var operation = TableOperation.Retrieve<UserEntity>(TableConstants.UserPartitionKey, userId);
+                var result = await _table.ExecuteAsync(operation);
+                return result.Result as UserEntity;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         public async Task AddUser(UserEntity user)

--- a/src/Functions/Repositories/UserRepository.cs
+++ b/src/Functions/Repositories/UserRepository.cs
@@ -22,16 +22,9 @@ namespace Functions.Repositories
 
         public async Task<UserEntity> GetUserAsync(string userId)
         {
-            try
-            {
-                var operation = TableOperation.Retrieve<UserEntity>(TableConstants.UserPartitionKey, userId);
-                var result = await _table.ExecuteAsync(operation);
-                return result.Result as UserEntity;
-            }
-            catch
-            {
-                return null;
-            }
+            var operation = TableOperation.Retrieve<UserEntity>(TableConstants.UserPartitionKey, userId);
+            var result = await _table.ExecuteAsync(operation);
+            return result.Result as UserEntity;
         }
 
         public async Task AddUser(UserEntity user)

--- a/src/Spotify/Models/PlayHistory.cs
+++ b/src/Spotify/Models/PlayHistory.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Spotify.Models
+{
+    public class PlayHistory
+    {
+        public PlayHistoryItem[] items { get; set; }
+    }
+
+    public class PlayHistoryItem
+    {
+        public Track track { get; set; }
+
+        public DateTime played_at { get; set; }
+    }
+}

--- a/src/Spotify/SpotifyApi.cs
+++ b/src/Spotify/SpotifyApi.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -69,6 +70,17 @@ namespace Spotify
             currentTrackResponse.EnsureSuccessStatusCode();
 
             return await currentTrackResponse.Content.ReadAsAsync<CurrentTrack>();
+        }
+
+        public static async Task<PlayHistory> GetRecentlyPlayedTracksAsync(string accessToken)
+        {
+            var recentlyPlayedRequest = new HttpRequestMessage(HttpMethod.Get, $"{Config.ApiBaseUrl}/v1/me/player/recently-played?limit=50");
+            recentlyPlayedRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+            var recentlyPlayedResponse = await _client.SendAsync(recentlyPlayedRequest);
+            recentlyPlayedResponse.EnsureSuccessStatusCode();
+
+            return await recentlyPlayedResponse.Content.ReadAsAsync<PlayHistory>();
         }
     }
 }


### PR DESCRIPTION
API reference; https://developer.spotify.com/documentation/web-api/reference/player/get-recently-played/

Gets 50 of the most recently played tracks by a specific user. Not exactly a "history" endpoint, since you can't seek further back.

Long term, could potentially use to generate other cool statistics, "what is the most popular band, genre, song right now among all our users"? 

Could potentially also sample periodically and build a history.. but that might be overstepping a bit.